### PR TITLE
Wip on redisgraph fuzztest VM 

### DIFF
--- a/terraform/redisgraph-fuzztester/output.tf
+++ b/terraform/redisgraph-fuzztester/output.tf
@@ -1,0 +1,8 @@
+
+output "server_public_ip" {
+  value = ["${aws_instance.server[0].public_ip}"]
+}
+
+output "server_private_ip" {
+  value = ["${aws_instance.server[0].private_ip}"]
+}

--- a/terraform/redisgraph-fuzztester/resources.tf
+++ b/terraform/redisgraph-fuzztester/resources.tf
@@ -1,0 +1,73 @@
+# provider
+provider "aws" {
+  region = "${var.region}"
+}
+
+# This is the shared resources bucket key -- you will need it across environments
+data "terraform_remote_state" "shared_resources" {
+  backend = "s3"
+  config = {
+    bucket = "performance-cto-group"
+    key    = "benchmarks/infrastructure/shared_resources.tfstate"
+    region = "us-east-1"
+  }
+}
+
+# This is the bucket holding this specific setup tfstate
+terraform {
+  backend "s3" {
+    bucket = "performance-cto-group"
+    key    = "benchmarks/infrastructure/redisgraph-fuzztester.tfstate"
+    region = "us-east-1"
+  }
+}
+
+resource "aws_instance" "server" {
+  count                  = "${var.server_instance_count}"
+  ami                    = "${var.instance_ami}"
+  instance_type          = "${var.instance_type}"
+  subnet_id              = data.terraform_remote_state.shared_resources.outputs.subnet_public_id
+  vpc_security_group_ids = ["${data.terraform_remote_state.shared_resources.outputs.performance_cto_sg_id}"]
+  key_name               = "${var.key_name}"
+
+  root_block_device {
+    volume_size           = "${var.instance_volume_size}"
+    volume_type           = "${var.instance_volume_type}"
+    encrypted             = "${var.instance_volume_encrypted}"
+    delete_on_termination = true
+  }
+
+  volume_tags = {
+    Name        = "ebs_block_device-${var.setup_name}-${count.index + 1}"
+    RedisModule = "${var.redis_module}"
+  }
+
+  tags = {
+    Name        = "${var.setup_name}-${count.index + 1}"
+    RedisModule = "${var.redis_module}"
+  }
+
+  ################################################################################
+  # This will ensure we wait here until the instance is ready to receive the ssh connection 
+  ################################################################################
+  provisioner "remote-exec" {
+    script = "./../../scripts/wait_for_instance.sh"
+    connection {
+      host        = "${self.public_ip}" # The `self` variable is like `this` in many programming languages
+      type        = "ssh"               # in this case, `self` is the resource (the server).
+      user        = "${var.ssh_user}"
+      private_key = "${file(var.private_key)}"
+      #need to increase timeout to larger then 5m for metal instances
+      timeout = "15m"
+      agent = "false"
+    }
+
+  }
+
+  ################################################################################
+  # Deployment related
+  ################################################################################
+  # ...
+  # ...
+  # ...
+}

--- a/terraform/redisgraph-fuzztester/variables.tf
+++ b/terraform/redisgraph-fuzztester/variables.tf
@@ -1,0 +1,115 @@
+# Variables
+
+variable "setup_name" {
+  description = "setup name"
+  default     = "redisgraph-fuzztester"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "server_instance_count" {
+  default = "1"
+}
+
+variable "instance_ami" {
+  description = "AMI for aws EC2 instance - us-east-2 Ubuntu 18.04 LTS perf-cto-debug-ubuntu18.04-redis-oss"
+  default     = "ami-040dd5a87e9eb7641"
+}
+
+variable "instance_device_name" {
+  description = "EC2 instance device name"
+  default     = "/dev/sda1"
+}
+
+variable "redis_module" {
+  description = "redis_module"
+  default     = "RedisGraph"
+}
+
+variable "instance_volume_size" {
+  description = "EC2 instance volume_size"
+  default     = "128"
+}
+
+
+variable "instance_volume_type" {
+  description = "EC2 instance volume_type"
+  default     = "gp2"
+}
+
+variable "instance_volume_iops" {
+  description = "EC2 instance volume_iops"
+  default     = "384"
+}
+
+variable "instance_volume_encrypted" {
+  description = "EC2 instance instance_volume_encrypted"
+  default     = "false"
+}
+
+variable "instance_root_block_device_encrypted" {
+  description = "EC2 instance instance_root_block_device_encrypted"
+  default     = "false"
+}
+
+# Model	t2.xlarge	
+variable "instance_type" {
+  description = "type for aws EC2 instance"
+  default     = "t2.xlarge"
+}
+
+variable "instance_cpu_core_count" {
+  description = "CPU core count for aws EC2 instance"
+  default     = 2
+}
+
+variable "instance_cpu_threads_per_core" {
+  description = "CPU threads per core for aws EC2 instance"
+  default     = 1
+}
+
+
+variable "instance_cpu_threads_per_core_hyperthreading" {
+  description = "CPU threads per core when hyperthreading is enabled for aws EC2 instance"
+  default     = 2
+}
+
+
+variable "instance_network_interface_plus_count" {
+  description = "number of additional network interfaces to add to aws EC2 instance"
+  default     = 0
+}
+
+
+variable "os" {
+  description = "os"
+  default     = "ubuntu18.04"
+}
+
+
+variable "ssh_user" {
+  description = "ssh_user"
+  default     = "ubuntu"
+}
+
+
+variable "private_key" {
+  description = "private key"
+  default     = "./../../../pems/perf-cto-joint-tasks.pem"
+}
+
+
+variable "public_key" {
+  description = "public key"
+  default     = "./../../../pems/perf-cto-joint-tasks.pub"
+}
+
+
+variable "key_name" {
+  description = "key name"
+  default     = "perf-cto-joint-tasks"
+}
+
+


### PR DESCRIPTION
(right now is a plain VM from an old base image but we can alter as much as we want on the following 3 files. 
The overall ideia is that:
- the `variables.tf` file will contain the static configs we want to use ( like VM type, key, etc... ).
- the `resources.tf` describes the added resources to the infrastructure and relies on private s3 backends ( a common one that should not be touched, and one with the name of the deployment `benchmarks/infrastructure/shared_resources.tfstate` so that we can work in an non-local manner and persist configs ). You should add more steps after `# Deployment related`
- the `output.tf` file will contain the outputs we're interested to use after the deployment succeeds.

To have a look and try out changes ( feel free to destroy the environment as many times you want )

```
cd testing-infrastructure/terraform/redisgraph-fuzztester
terraform init ( once )
terraform apply ( check and yes or no )
```

sample output:
```
/testing-infrastructure/terraform/redisgraph-fuzztester$ terraform apply
data.terraform_remote_state.shared_resources: Refreshing state...
(...)
(...)
aws_instance.server[0]: Creation complete after 1m30s [id=i-0e3edcd70e11089ca]
Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
Outputs:
server_private_ip = [
  "10.3.0.37",
]
server_public_ip = [
  "18.216.37.137",
]
```