### PR TITLE
Fixed client instance count on redistimeseries ci setup

### DIFF
--- a/terraform/oss-standalone-redistimeseries-m5/variables.tf
+++ b/terraform/oss-standalone-redistimeseries-m5/variables.tf
@@ -150,6 +150,6 @@ variable "client_instance_type" {
 }
 
 variable "client_instance_count" {
-  default = "4"
+  default = "1"
 }
 


### PR DESCRIPTION
We were having 4 client instances ( due to some preliminary tests ) and we should have only 1 for this setup:
```
client_public_ip = [
  [
    "3.133.142.189",
    "3.143.22.71",
    "3.16.49.113",
    "3.141.3.116",
  ],
]
```