### PR TITLE
Following cost/usage recommendations changes

### DIFF
--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/variables.tf
@@ -64,17 +64,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/variables.tf
@@ -64,17 +64,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/variables.tf
@@ -64,17 +64,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/variables.tf
@@ -64,17 +64,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/variables.tf
@@ -74,12 +74,12 @@ variable "instance_volume_size" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-amd64-ubuntu22.04-c6i.16xlarge/variables.tf
+++ b/terraform/oss-standalone-amd64-ubuntu22.04-c6i.16xlarge/variables.tf
@@ -74,12 +74,12 @@ variable "instance_volume_size" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-arm64-ubuntu22.04-c6gn.16xlarge/variables.tf
+++ b/terraform/oss-standalone-arm64-ubuntu22.04-c6gn.16xlarge/variables.tf
@@ -74,12 +74,12 @@ variable "instance_volume_size" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redisbloom-m5/variables.tf
+++ b/terraform/oss-standalone-redisbloom-m5/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redisearch-m5/variables.tf
+++ b/terraform/oss-standalone-redisearch-m5/variables.tf
@@ -70,12 +70,12 @@ variable "instance_device_name" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "redis_module" {
@@ -91,12 +91,12 @@ variable "instance_volume_size" {
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "client_instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 

--- a/terraform/oss-standalone-redisearch-m5d/variables.tf
+++ b/terraform/oss-standalone-redisearch-m5d/variables.tf
@@ -68,12 +68,12 @@ variable "instance_device_name" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "redis_module" {
@@ -89,12 +89,12 @@ variable "instance_volume_size" {
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "client_instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 

--- a/terraform/oss-standalone-redisgraph-r5-baseline/variables.tf
+++ b/terraform/oss-standalone-redisgraph-r5-baseline/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redisgraph-r5-centos7/variables.tf
+++ b/terraform/oss-standalone-redisgraph-r5-centos7/variables.tf
@@ -89,12 +89,12 @@ variable "instance_volume_iops" {
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "client_instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 

--- a/terraform/oss-standalone-redisgraph-r5-comparison/variables.tf
+++ b/terraform/oss-standalone-redisgraph-r5-comparison/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redisgraph-r5/variables.tf
+++ b/terraform/oss-standalone-redisgraph-r5/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redisjson-m5/variables.tf
+++ b/terraform/oss-standalone-redisjson-m5/variables.tf
@@ -70,12 +70,12 @@ variable "instance_device_name" {
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "redis_module" {
@@ -91,12 +91,12 @@ variable "instance_volume_size" {
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "client_instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 

--- a/terraform/oss-standalone-redistimeseries-m5/variables.tf
+++ b/terraform/oss-standalone-redistimeseries-m5/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redistimeseries-m5a.8xlarge/variables.tf
+++ b/terraform/oss-standalone-redistimeseries-m5a.8xlarge/variables.tf
@@ -86,17 +86,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-redistimeseries-m6i.8xlarge/variables.tf
+++ b/terraform/oss-standalone-redistimeseries-m6i.8xlarge/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {

--- a/terraform/oss-standalone-us-east-2-amd64-ubuntu18.04-m6i.8xlarge/variables.tf
+++ b/terraform/oss-standalone-us-east-2-amd64-ubuntu18.04-m6i.8xlarge/variables.tf
@@ -79,17 +79,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "256"
+  default     = "96"
 }
 
 variable "instance_volume_type" {
   description = "EC2 instance volume_type"
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "instance_volume_iops" {
   description = "EC2 instance volume_iops"
-  default     = "384"
+  default     = "100"
 }
 
 variable "instance_volume_encrypted" {


### PR DESCRIPTION
- gp2 to gp3
- iops from 308 to 100
- volume size from 256gb to 96gb