### PR TITLE
oss-standalone-redisearch-m7-aarch64: bump root volume default to 256GB

### DIFF
--- a/terraform/oss-standalone-redisearch-m7-aarch64/variables.tf
+++ b/terraform/oss-standalone-redisearch-m7-aarch64/variables.tf
@@ -94,13 +94,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "128"
+  # The aarch64 perf base image AMI (ami-07b2bd887269522a3) has a root
+  # snapshot >= 256GB, so requesting anything smaller makes RunInstances
+  # fail with InvalidBlockDeviceMapping. Keep >= 256 until we rebuild a
+  # smaller AMI.
+  default     = "256"
 }
 
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "64"
+  default     = "256"
 }
 
 variable "client_instance_volume_type" {


### PR DESCRIPTION
The aarch64 perf base image AMI (ami-07b2bd887269522a3) has a root snapshot ≥ 256GB, so terraform apply on the m7-aarch64 setup fails at RunInstances:

```
Error: creating EC2 Instance: ... InvalidBlockDeviceMapping:
  Volume of size 128GB is smaller than snapshot 'snap-0f5e61acf36e9dc2f',
  expect size >= 256GB
```

Observed in RediSearch PR #9258 run [24859385661](https://github.com/RediSearch/RediSearch/actions/runs/24859385661) on all 3 aarch64 benchmark jobs (setup hash `8cf407b5bf...`).

Bumps both \`instance_volume_size\` and \`client_instance_volume_size\` defaults from 128/64 to 256. No other setups touched.

Can be reverted when the aarch64 perf base AMI is rebuilt with a smaller root snapshot.