### PR TITLE
Add team tag to remaining 30 deployment dirs

### DIFF
--- a/terraform/bench-client-us-east-2b/bench-client-resources.tf
+++ b/terraform/bench-client-us-east-2b/bench-client-resources.tf
@@ -25,6 +25,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -36,6 +37,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/benchmarks_redislabs_infrastructure/proxy.tf
+++ b/terraform/benchmarks_redislabs_infrastructure/proxy.tf
@@ -20,11 +20,13 @@ resource "aws_instance" "proxy_instance" {
   volume_tags = {
     Environment = "${var.environment}"
     Name        = "ebs_block_device-benchmarks.redislabs.com-PROXY-${count.index + 1}"
+    team           = "performance a&o"
   }
 
   tags = {
     Environment = "${var.environment}"
     Name        = "benchmarks.redislabs.com-PROXY-${count.index + 1}"
+    team           = "performance a&o"
   }
 
 

--- a/terraform/benchmarks_redislabs_infrastructure/resources.tf
+++ b/terraform/benchmarks_redislabs_infrastructure/resources.tf
@@ -45,12 +45,14 @@ resource "aws_instance" "monitoring_instance" {
     Environment = "${var.environment}"
     Name        = "ebs_block_device-${var.setup_name}-${count.index + 1}"
     RedisModule = "${var.redis_module}"
+    team           = "performance a&o"
   }
 
   tags = {
     Environment = "${var.environment}"
     Name        = "${var.setup_name}-${count.index + 1}"
     RedisModule = "${var.redis_module}"
+    team           = "performance a&o"
   }
 
 

--- a/terraform/gp2-c5-2xlarge-55gb/db-resources.tf
+++ b/terraform/gp2-c5-2xlarge-55gb/db-resources.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -37,6 +38,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/gp3-c5-2xlarge-42gb/db-resources.tf
+++ b/terraform/gp3-c5-2xlarge-42gb/db-resources.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -37,6 +38,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/gp3-c5-2xlarge-55gb/db-resources.tf
+++ b/terraform/gp3-c5-2xlarge-55gb/db-resources.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -37,6 +38,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/monitoring_infrastructure/resources.tf
+++ b/terraform/monitoring_infrastructure/resources.tf
@@ -44,12 +44,14 @@ resource "aws_instance" "monitoring_instance" {
     Environment = "${var.environment}"
     Name        = "ebs_block_device-${var.setup_name}-${count.index + 1}"
     RedisModule = "${var.redis_module}"
+    team           = "performance a&o"
   }
 
   tags = {
     Environment = "${var.environment}"
     Name        = "${var.setup_name}-${count.index + 1}"
     RedisModule = "${var.redis_module}"
+    team           = "performance a&o"
   }
 
 

--- a/terraform/oss-k8s-milvus-1node-m6i/bench-client-resources.tf
+++ b/terraform/oss-k8s-milvus-1node-m6i/bench-client-resources.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -37,6 +38,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-k8s-milvus-1node-m6i/db-resources.tf
+++ b/terraform/oss-k8s-milvus-1node-m6i/db-resources.tf
@@ -27,6 +27,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -38,6 +39,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-multi-arch-comp-amd-arm-intel-4xlarge-redis-7.2-redis-8.0.0/variables.tf
+++ b/terraform/oss-multi-arch-comp-amd-arm-intel-4xlarge-redis-7.2-redis-8.0.0/variables.tf
@@ -141,5 +141,6 @@ locals {
     github_repo    = var.github_repo
     github_sha     = var.github_sha
     timeout_secs   = var.timeout_secs
+    team           = "performance a&o"
   }
 }

--- a/terraform/oss-multi-arch-comp-metal-amd-arm-intel-redis-latest/variables.tf
+++ b/terraform/oss-multi-arch-comp-metal-amd-arm-intel-redis-latest/variables.tf
@@ -141,5 +141,6 @@ locals {
     github_repo    = var.github_repo
     github_sha     = var.github_sha
     timeout_secs   = var.timeout_secs
+    team           = "performance a&o"
   }
 }

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/client-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/client-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-5/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/client-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/client-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-6.2/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/client-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/client-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge-redis-7.0/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/client-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/client-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu18.04-m6i.8xlarge/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/bench-client-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/bench-client-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu20.04-m6i.4xlarge/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-amd64-ubuntu22.04-c6i.16xlarge/db-resources.tf
+++ b/terraform/oss-standalone-amd64-ubuntu22.04-c6i.16xlarge/db-resources.tf
@@ -25,6 +25,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -36,6 +37,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-arm64-ubuntu24.04-c6gn.16xlarge/bench-client-resources.tf
+++ b/terraform/oss-standalone-arm64-ubuntu24.04-c6gn.16xlarge/bench-client-resources.tf
@@ -25,6 +25,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -36,6 +37,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-arm64-ubuntu24.04-c6gn.16xlarge/db-resources.tf
+++ b/terraform/oss-standalone-arm64-ubuntu24.04-c6gn.16xlarge/db-resources.tf
@@ -25,6 +25,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -36,6 +37,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-arm64-ubuntu24.04-c8g.16xlarge/bench-client-resources.tf
+++ b/terraform/oss-standalone-arm64-ubuntu24.04-c8g.16xlarge/bench-client-resources.tf
@@ -28,6 +28,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -39,6 +40,7 @@ resource "aws_instance" "client" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/oss-standalone-arm64-ubuntu24.04-c8g.16xlarge/db-resources.tf
+++ b/terraform/oss-standalone-arm64-ubuntu24.04-c8g.16xlarge/db-resources.tf
@@ -28,6 +28,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -39,6 +40,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-builder-arm64/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-builder-arm64/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-builder/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-builder/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu18.04-m6i.8xlarge-1/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu18.04-m6i.8xlarge-1/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
 

--- a/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu24.04-m7i.metal-24xl-1/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu24.04-m7i.metal-24xl-1/db-resources.tf
@@ -50,6 +50,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -61,6 +62,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu24.04-r8i.metal-48xl-1/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-sc-coordinator-amd64-ubuntu24.04-r8i.metal-48xl-1/db-resources.tf
@@ -50,6 +50,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -61,6 +62,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-sc-coordinator-arm64-ubuntu18.04-m6g.8xlarge-1/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-sc-coordinator-arm64-ubuntu18.04-m6g.8xlarge-1/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/redis-benchmarks-spec-sc-coordinator-arm64-ubuntu24.04-m8g.metal-24xl-1/db-resources.tf
+++ b/terraform/redis-benchmarks-spec-sc-coordinator-arm64-ubuntu24.04-m8g.metal-24xl-1/db-resources.tf
@@ -50,6 +50,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -61,6 +62,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################

--- a/terraform/search-scaling-client-us-east-1/db-resources.tf
+++ b/terraform/search-scaling-client-us-east-1/db-resources.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   tags = {
@@ -34,6 +35,7 @@ resource "aws_instance" "server" {
     github_repo  = "${var.github_repo}"
     github_sha   = "${var.github_sha}"
     timeout_secs = "${var.timeout_secs}"
+    team           = "performance a&o"
   }
 
   ################################################################################


### PR DESCRIPTION
## Summary
- Backfills `team = "performance a&o"` tag in `tags`/`volume_tags` blocks of `aws_instance` resources across 30 terraform deployment dirs missed by #152.
- Two dirs (`oss-multi-arch-comp-*`) use a `local.base_tags` merge() pattern, so the tag was added to `base_tags` instead.
- Total: 34 files changed, +66 lines.

## Why
Cost-explorer alert surfaced ~$45/hr of bench-fleet bleed in `us-east-2` attributable to dangling and untagged instances (31 ElastiCache m7g.2xlarge clusters + 97 EC2 bench/rs instances + 9 GCP bench-clients, all cleaned up out-of-band). Tagging at deploy time ensures future cleanups + cost-allocation rollups stay accurate.

## Test plan
- [ ] `terraform validate` on a sample dir
- [ ] Confirm the tag appears on a freshly-deployed instance via `aws ec2 describe-tags`
- [ ] Cost-explorer rollup by `team` tag picks up new instances after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)