### PR TITLE
WIP: Add RediSearch m7i metal standalone setup

### DIFF
--- a/terraform/oss-standalone-redisearch-m7-aarch64/variables.tf
+++ b/terraform/oss-standalone-redisearch-m7-aarch64/variables.tf
@@ -94,13 +94,17 @@ variable "redis_module" {
 
 variable "instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "128"
+  # The aarch64 perf base image AMI (ami-07b2bd887269522a3) has a root
+  # snapshot >= 256GB, so requesting anything smaller makes RunInstances
+  # fail with InvalidBlockDeviceMapping. Keep >= 256 until we rebuild a
+  # smaller AMI.
+  default     = "256"
 }
 
 
 variable "client_instance_volume_size" {
   description = "EC2 instance volume_size"
-  default     = "64"
+  default     = "256"
 }
 
 variable "client_instance_volume_type" {

--- a/terraform/oss-standalone-redisearch-m7i-metal/bench-client-resources.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/bench-client-resources.tf
@@ -1,0 +1,59 @@
+
+resource "aws_instance" "client" {
+  count                       = var.client_instance_count
+  ami                         = var.instance_ami
+  instance_type               = var.client_instance_type
+  subnet_id                   = data.terraform_remote_state.shared_resources.outputs.subnet_public_id
+  vpc_security_group_ids      = ["${data.terraform_remote_state.shared_resources.outputs.performance_cto_sg_id}"]
+  key_name                    = var.key_name
+  associate_public_ip_address = "true"
+  #placement_group             = data.terraform_remote_state.shared_resources.outputs.perf_cto_pg_name
+  availability_zone = "us-east-2a"
+
+  root_block_device {
+    volume_size           = var.instance_volume_size
+    volume_type           = var.instance_volume_type
+    encrypted             = var.instance_volume_encrypted
+    delete_on_termination = true
+  }
+
+  volume_tags = {
+    Environment    = "${var.environment}"
+    Project        = "${var.environment}"
+    Name           = "ebs_block_device-${var.setup_name}-CLIENT-${count.index + 1}"
+    setup          = "${var.setup_name}"
+    triggering_env = "${var.triggering_env}"
+    github_actor   = "${var.github_actor}"
+    github_org     = "${var.github_org}"
+    github_repo    = "${var.github_repo}"
+    github_sha     = "${var.github_sha}"
+    team           = "performance a&o"
+    timeout_secs   = "${var.timeout_secs}"
+  }
+
+  tags = {
+    Environment    = "${var.environment}"
+    Project        = "${var.environment}"
+    Name           = "${var.setup_name}-CLIENT-${count.index + 1}"
+    setup          = "${var.setup_name}"
+    triggering_env = "${var.triggering_env}"
+    github_actor   = "${var.github_actor}"
+    github_org     = "${var.github_org}"
+    github_repo    = "${var.github_repo}"
+    github_sha     = "${var.github_sha}"
+    team           = "performance a&o"
+    timeout_secs   = "${var.timeout_secs}"
+  }
+
+  ################################################################################
+  # This will ensure we wait here until the instance is ready to receive the ssh connection 
+  ################################################################################
+  # user_data = <<-EOF
+  #   #!/bin/bash
+  #   echo "Instance is ready" > /var/log/instance_ready.log
+  # EOF
+
+  ################################################################################
+  # Deployment related
+  ################################################################################
+}

--- a/terraform/oss-standalone-redisearch-m7i-metal/cloud-init-parca-agent.yaml
+++ b/terraform/oss-standalone-redisearch-m7i-metal/cloud-init-parca-agent.yaml
@@ -1,0 +1,72 @@
+#cloud-config
+
+# Server-side relabel config for parca-agent, mirrored from the
+# /etc/parca-agent.yml convention used on the Redis OSS benchmark runners:
+#   * drop every sample whose executable is not redis-server so Polar
+#     Signals storage/quota is spent on the module we actually profile
+#     (RediSearch code runs inside the redis-server process)
+#   * promote __meta_thread_id / thread_comm / process_pid to first-class
+#     labels so queries can filter by thread or pid
+#   * default role=primary, override to replica when `replicaof` is in the
+#     process cmdline
+write_files:
+  - path: /etc/parca-agent.yml
+    permissions: '0644'
+    owner: root:root
+    content: |
+      relabel_configs:
+        - source_labels: [__meta_thread_id]
+          target_label: thread_id
+
+        - source_labels: [__meta_thread_comm]
+          target_label: thread_name
+
+        - source_labels: [__meta_process_pid]
+          target_label: pid
+
+        # Drop everything that is NOT redis-server.
+        - source_labels: [__meta_process_executable_name]
+          regex: "^redis-server$"
+          action: keep
+
+        # Default: mark as primary.
+        - target_label: role
+          replacement: primary
+          action: replace
+
+        # Override: mark as replica if "replicaof" appears in cmdline.
+        - source_labels: [__meta_process_cmdline]
+          regex: '.*replicaof.*'
+          target_label: role
+          replacement: replica
+          action: replace
+
+# Parca agent install + wire the config.
+#
+# Channel:
+#   `stable` -> v0.46.0, works with JWT tokens that embed `projectId`.
+#   `edge`   -> v0.47.1+, required when the token is `psc_v1_<secret>_<id>`
+#              (no project binding in the token -- v0.46.0 does not honor
+#              the projectID gRPC header in that case).
+#
+# GRPC headers:
+#   When `parca_agent_project_id` is set, parca-agent is told to route writes
+#   to that project via `--remote-store-grpc-headers=projectID=<id>` (this is
+#   exactly how Polar Signals' own k8s `manifests.yaml` wires the DaemonSet).
+#   Leave the project id empty when using a JWT token that already carries
+#   the project id in its claims.
+snap:
+  commands:
+    - [install, parca-agent, --classic, --channel=${parca_agent_snap_channel}]
+    - [set, parca-agent, config-path=/etc/parca-agent.yml]
+    - [
+        set,
+        parca-agent,
+        remote-store-bearer-token=${parca_agent_token},
+      ]
+    - [
+        set,
+        parca-agent,
+        remote-store-grpc-headers=projectID=${parca_agent_project_id},
+      ]
+    - [start, --enable, parca-agent]

--- a/terraform/oss-standalone-redisearch-m7i-metal/common.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/common.tf
@@ -1,0 +1,11 @@
+
+################################################################################
+# This is the bucket holding this specific setup tfstate
+################################################################################
+terraform {
+  backend "s3" {
+    bucket = "performance-cto-group"
+    region = "us-east-1"
+  }
+}
+

--- a/terraform/oss-standalone-redisearch-m7i-metal/db-resources.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/db-resources.tf
@@ -1,0 +1,60 @@
+resource "aws_instance" "server" {
+  count         = var.server_instance_count
+  ami           = var.instance_ami
+  instance_type = var.server_instance_type
+
+  subnet_id                   = data.terraform_remote_state.shared_resources.outputs.subnet_public_id
+  vpc_security_group_ids      = ["${data.terraform_remote_state.shared_resources.outputs.performance_cto_sg_id}"]
+  key_name                    = var.key_name
+  associate_public_ip_address = "true"
+  #placement_group             = data.terraform_remote_state.shared_resources.outputs.perf_cto_pg_name
+  availability_zone = "us-east-2a"
+
+  root_block_device {
+    volume_size           = var.instance_volume_size
+    volume_type           = var.instance_volume_type
+    encrypted             = var.instance_volume_encrypted
+    delete_on_termination = true
+  }
+
+  volume_tags = {
+    Environment    = "${var.environment}"
+    Project        = "${var.environment}"
+    Name           = "ebs_block_device-${var.setup_name}-DB-${count.index + 1}"
+    setup          = "${var.setup_name}"
+    triggering_env = "${var.triggering_env}"
+    github_actor   = "${var.github_actor}"
+    github_org     = "${var.github_org}"
+    github_repo    = "${var.github_repo}"
+    github_sha     = "${var.github_sha}"
+    team           = "performance a&o"
+    timeout_secs   = "${var.timeout_secs}"
+  }
+
+  tags = {
+    Environment    = "${var.environment}"
+    Project        = "${var.environment}"
+    Name           = "${var.setup_name}-DB-${count.index + 1}"
+    setup          = "${var.setup_name}"
+    triggering_env = "${var.triggering_env}"
+    github_actor   = "${var.github_actor}"
+    github_org     = "${var.github_org}"
+    github_repo    = "${var.github_repo}"
+    github_sha     = "${var.github_sha}"
+    team           = "performance a&o"
+    timeout_secs   = "${var.timeout_secs}"
+  }
+
+  ################################################################################
+  # Polar Signals Parca agent configuration (optional)
+  ################################################################################
+  user_data = var.enable_parca_agent ? templatefile("${path.module}/cloud-init-parca-agent.yaml", {
+    parca_agent_token        = var.parca_agent_token
+    parca_agent_project_id   = var.parca_agent_project_id
+    parca_agent_snap_channel = var.parca_agent_snap_channel
+  }) : null
+
+  ################################################################################
+  # Deployment related
+  ################################################################################
+}

--- a/terraform/oss-standalone-redisearch-m7i-metal/output.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/output.tf
@@ -1,0 +1,15 @@
+output "server_public_ip" {
+  value = ["${aws_instance.server[0].public_ip}"]
+}
+
+output "server_private_ip" {
+  value = ["${aws_instance.server[0].private_ip}"]
+}
+
+output "client_public_ip" {
+  value = ["${aws_instance.client[0].public_ip}"]
+}
+
+output "client_private_ip" {
+  value = ["${aws_instance.client[0].private_ip}"]
+}

--- a/terraform/oss-standalone-redisearch-m7i-metal/shared_resources.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/shared_resources.tf
@@ -1,0 +1,26 @@
+# provider
+provider "aws" {
+  region = var.region
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.94.1"
+    }
+  }
+}
+
+################################################################################
+# This is the shared resources bucket key -- you will need it across environments like security rules,etc...
+# !! do not change this !!
+################################################################################
+data "terraform_remote_state" "shared_resources" {
+  backend = "s3"
+  config = {
+    bucket = "performance-cto-group"
+    key    = "benchmarks/infrastructure/shared_resources.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/oss-standalone-redisearch-m7i-metal/variables.tf
+++ b/terraform/oss-standalone-redisearch-m7i-metal/variables.tf
@@ -1,0 +1,209 @@
+################################################################################
+# Variables used for deployment tag
+################################################################################
+
+variable "setup_name" {
+  description = "setup name"
+  default     = "oss-redisearch-m7i-metal"
+}
+variable "github_actor" {
+  description = "The name of the person or app that initiated the deployment."
+  default     = "N/A"
+}
+
+variable "github_repo" {
+  description = "	The owner and repository name. For example, testing-infrastructure."
+  default     = "N/A"
+}
+
+variable "triggering_env" {
+  description = "	The triggering environment. For example circleci."
+  default     = "N/A"
+}
+
+variable "environment" {
+  description = "	The cost tag."
+  default     = "RediSearch"
+}
+
+variable "github_org" {
+  description = "	The owner name. For example, RedisModules."
+  default     = "N/A"
+}
+
+variable "github_sha" {
+  description = "The commit SHA that triggered the deployment."
+  default     = "N/A"
+}
+
+variable "timeout_secs" {
+  description = "The maximum time to wait prior destroying the VM via the watchdog."
+  default     = "3600"
+}
+
+
+
+################################################################################
+# Access keys
+################################################################################
+variable "private_key" {
+  description = "private key"
+  default     = "/tmp/benchmarks.redislabs.pem"
+}
+
+variable "key_name" {
+  description = "key name"
+  default     = "perf-cto-us-east-2"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+# (Ubuntu 24.04, memtier_benchmark v=255.255.255 sha=1e7877b5:0 and redis Redis server v=8.6.0 sha=006e6a6a:0)
+# https://us-east-2.console.aws.amazon.com/ec2/home?region=us-east-2#ImageDetails:imageId=ami-0ea6aaf5946625af3
+variable "instance_ami" {
+  description = "AMI for aws EC2 instance - us-east-2 Ubuntu 24.04 - perf-base-image-ubuntu24.04-m6i.8xlarge-20260216-1253"
+  default     = "ami-0ea6aaf5946625af3"
+}
+
+variable "instance_device_name" {
+  description = "EC2 instance device name"
+  default     = "/dev/sda1"
+}
+
+
+variable "instance_volume_type" {
+  description = "EC2 instance volume_type"
+  default     = "gp3"
+}
+
+variable "instance_volume_iops" {
+  description = "EC2 instance volume_iops"
+  default     = "100"
+}
+
+variable "redis_module" {
+  description = "redis_module"
+  default     = "N/A"
+}
+
+variable "instance_volume_size" {
+  description = "EC2 instance volume_size"
+  default     = "128"
+}
+
+
+variable "client_instance_volume_size" {
+  description = "EC2 instance volume_size"
+  default     = "64"
+}
+
+variable "client_instance_volume_type" {
+  description = "EC2 instance volume_type"
+  default     = "gp3"
+}
+
+
+variable "instance_volume_encrypted" {
+  description = "EC2 instance instance_volume_encrypted"
+  default     = "false"
+}
+
+variable "instance_root_block_device_encrypted" {
+  description = "EC2 instance instance_root_block_device_encrypted"
+  default     = "false"
+}
+
+variable "instance_cpu_threads_per_core" {
+  description = "CPU threads per core for aws EC2 instance"
+  default     = 1
+}
+
+variable "instance_cpu_threads_per_core_hyperthreading" {
+  description = "CPU threads per core when hyperthreading is enabled for aws EC2 instance"
+  default     = 2
+}
+
+variable "instance_network_interface_plus_count" {
+  description = "number of additional network interfaces to add to aws EC2 instance"
+  default     = 0
+}
+
+variable "os" {
+  description = "os"
+  default     = "ubuntu24.04"
+}
+
+variable "ssh_user" {
+  description = "ssh_user"
+  default     = "ubuntu"
+}
+
+################################################################################
+# Specific DB machine variables
+################################################################################
+# m7i.metal-24xl 96 VCPUs 384 GB MEM Intel Xeon 8488C (Sapphire Rapids)
+variable "server_instance_type" {
+  description = "type for aws EC2 instance"
+  default     = "m7i.metal-24xl"
+}
+
+
+variable "server_instance_count" {
+  default = "1"
+}
+
+################################################################################
+# Specific Client machine variables
+################################################################################
+# m7i.4xlarge 	16 VCPUs
+
+variable "client_instance_type" {
+  description = "type for aws EC2 instance"
+  default     = "m7i.4xlarge"
+}
+
+variable "client_instance_count" {
+  default = "1"
+}
+
+################################################################################
+# Polar Signals / Parca agent configuration
+################################################################################
+variable "enable_parca_agent" {
+  description = "Enable Polar Signals Parca agent installation on DB server"
+  type        = bool
+  default     = false
+}
+
+variable "parca_agent_token" {
+  description = "Bearer token for Polar Signals remote store (required if enable_parca_agent is true)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "parca_agent_project_id" {
+  description = <<-EOT
+    Polar Signals project id. Required when parca_agent_token is a
+    `psc_v1_<secret>_<serviceAccountId>` (no project binding in the
+    token) -- passed to parca-agent as `--remote-store-grpc-headers=projectID=<id>`
+    so the server can route writes to the right project. Leave empty
+    when parca_agent_token is a JWT (`eyJ...`) with `projectId` already
+    embedded in its claims.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "parca_agent_snap_channel" {
+  description = <<-EOT
+    Snap channel for parca-agent. v0.46.0 (stable) does not honor the
+    projectID gRPC header with `psc_v1_` tokens; use `edge` (v0.47.1+)
+    for that workflow. Safe to leave as `stable` when using a JWT token
+    with the project id embedded.
+  EOT
+  type        = string
+  default     = "stable"
+}


### PR DESCRIPTION
## Summary

Adds a RediSearch standalone terraform setup backed by an `m7i.metal-24xl` DB/server instance and the existing `m7i.4xlarge` benchmark client shape.

## Notes

- The setup is based on `oss-standalone-redisearch-m7`.
- The DB/server instance changes from `m7i.8xlarge` to `m7i.metal-24xl`.
- The explicit CPU pinning from the VM setup is removed so the metal instance uses its full default CPU layout.
- The standard `server_*` and `client_*` terraform outputs are preserved for `redisbench-admin run-remote`.

## Validation

- `terraform fmt -check terraform/oss-standalone-redisearch-m7i-metal`
- Used by `redisearch-benchmarks` workflow runs through `TESTING_INFRASTRUCTURE_BRANCH=redisearch-m7i-metal-standalone` and `TF_OVERRIDE_REMOTE=/terraform/oss-standalone-redisearch-m7i-metal`.

Marked WIP while benchmark validation finishes.