### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+<!-- TODO: one paragraph describing what this repo does -->
+
+## Local setup
+
+<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+
+```bash
+# Example
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-in-pipeline`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+
+## Running tests
+
+<!-- TODO: exact command to run tests -->
+
+```bash
+# Example
+make test
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,33 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 
 ## Project overview
 
-<!-- TODO: one paragraph describing what this repo does -->
+`testing-infrastructure` provisions and manages the AWS-based performance testing infrastructure used by the Redis performance team. It is a collection of Terraform root modules (one per subdirectory under `terraform/`) that spin up golden images, benchmark client VMs, Redis OSS/RE server setups, and shared networking resources (VPC, security groups, placement groups, EIPs). Each module stores its state in a shared S3 backend (`performance-cto-group`) and reads shared networking outputs via `terraform_remote_state`. There is no application code -- the repo is pure Infrastructure-as-Code (HCL) plus helper shell scripts that install Redis, memtier_benchmark, and other benchmark tooling onto the provisioned VMs.
 
 ## Local setup
 
-<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+### Prerequisites
+
+- [awscli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Terraform](https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip) (>= 0.13.5) on `$PATH`
+- [ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html) installed
+- SSH key pair at `~/.ssh/perf-ci.pem` (private) and `~/.ssh/perf-ci.pub` (public)
 
 ```bash
-# Example
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
+# Clone including the automata submodule
+git clone --recurse-submodules git@github.com:redis-performance/testing-infrastructure.git
+cd testing-infrastructure
+
+# Install system dependencies (zip, and Terraform 0.13.5 if not found)
+./install_deps.sh
+```
+
+Required environment variables (needed by every Terraform module):
+
+```bash
+export EC2_REGION=us-east-2
+export EC2_ACCESS_KEY=<aws-access-key-id>
+export EC2_SECRET_KEY=<aws-secret-access-key>
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES   # macOS only
 ```
 
 ## Branch naming
@@ -24,30 +41,35 @@ Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-i
 
 - Match the style already in the file you are editing.
 - Prefer clear, minimal changes over large refactors unless explicitly asked.
-- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not add comments that describe *what* the code does -- only add comments when the *why* is non-obvious.
 - Do not introduce new dependencies without checking with the maintainer.
+- Variable defaults, resource tags, and backend bucket/key paths must match the naming convention of the surrounding modules.
 
-## Running tests
+## Running tests / validation
 
-<!-- TODO: exact command to run tests -->
+There is no automated unit-test suite. Validate every module you touch with:
 
 ```bash
-# Example
-make test
+cd terraform/<setup-name>
+terraform init
+terraform validate
+terraform plan
 ```
 
-Always run tests before declaring a task complete.
+`terraform validate` must exit 0. `terraform plan` must complete without errors and the planned diff must match the intended change. Always run this before declaring a task complete.
 
 ## How to submit changes
 
 1. Create a branch: `git checkout -b <type>/<description>`.
 2. Commit with a clear message focused on *why*, not *what*.
-3. Open a pull request against `main`.
-4. Do **not** push directly to `main`.
+3. Open a pull request against `master`.
+4. Do **not** push directly to `master`.
 
 ## What to avoid
 
 - Do not reformat files unrelated to your change.
-- Do not remove error handling or tests.
-- Do not commit secrets, credentials, or large binary files.
+- Do not remove error handling or provisioner blocks.
+- Do not commit secrets, credentials, `.pem` keys, or large binary files.
 - Do not amend published commits.
+- Do not change the S3 backend bucket (`performance-cto-group`) or state key paths -- these are shared across the team and a wrong change will corrupt remote state.
+- Do not run `terraform apply` or `terraform destroy` in CI/automation contexts without explicit maintainer instruction; these commands provision or destroy real AWS infrastructure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,51 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
+This repo manages Terraform configurations that provision AWS-based performance testing infrastructure (golden images, benchmark client VMs, Redis/RE server setups, and shared networking resources). Each subdirectory under `terraform/` is a self-contained Terraform root module.
+
+### Prerequisites
+
+- [awscli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Terraform](https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip) (>= 0.13.5) installed and on `$PATH`
+- [ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html) installed
+- SSH key pair at `~/.ssh/perf-ci.pem` (private) and `~/.ssh/perf-ci.pub` (public) - request these from the team
 
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+# Clone the repo (including the automata submodule)
+git clone --recurse-submodules git@github.com:redis-performance/testing-infrastructure.git
+cd testing-infrastructure
+
+# Install system dependencies (installs zip and, if needed, Terraform 0.13.5)
+./install_deps.sh
+```
+
+### Required environment variables
+
+Every Terraform module and Ansible script expects these variables to be set:
+
+```bash
+export EC2_REGION=us-east-2
+export EC2_ACCESS_KEY=<your-aws-access-key-id>
+export EC2_SECRET_KEY=<your-aws-secret-access-key>
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES   # macOS only -- harmless on Linux
+```
+
+### Working with a specific setup
+
+Each directory under `terraform/` is an independent root module with its own remote S3 backend. To bring one up:
+
+```bash
+cd terraform/<setup-name>   # e.g. terraform/oss-standalone-amd64-ubuntu22.04-c6i.16xlarge
+terraform init
+terraform validate
+terraform plan
+terraform apply
+```
+
+To tear it down when done:
+
+```bash
+terraform destroy
 ```
 
 ## Branch naming
@@ -31,21 +69,26 @@ Example: `feat/add-pipeline-mode`
 
 ## Submitting changes
 
-1. Fork or create a branch from `main`.
+1. Fork or create a branch from `master`.
 2. Make your changes with clear, atomic commits.
-3. Open a pull request against `main` with a descriptive title and summary.
+3. Open a pull request against `master` with a descriptive title and summary.
 4. Address review comments promptly; force-push to the same branch to update.
 
-## Testing
+## Testing / validation
 
-- All new behaviour must be covered by tests.
-- Existing tests must pass: run the test suite locally before opening a PR.
-- Coverage should not decrease.
+There is no automated unit-test suite; correctness is validated by linting and a dry-run plan. Before opening a PR, run the following against every module you touched:
 
-<!-- TODO: add the exact test command for this repo -->
+```bash
+cd terraform/<setup-name>
+terraform init
+terraform validate
+terraform plan
+```
+
+`terraform validate` must exit 0. `terraform plan` must produce no errors and the diff must match your intent.
 
 ## Review process
 
 - At least one maintainer approval is required before merge.
 - CI must be green.
-- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.
+- Maintainers may request changes or close PRs that do not meet the bar -- this is normal and not personal.


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)