### PR TITLE
oss-standalone-redisearch-m5: port parca-agent config from m7

### DIFF
--- a/terraform/oss-standalone-redisearch-m5/cloud-init-parca-agent.yaml
+++ b/terraform/oss-standalone-redisearch-m5/cloud-init-parca-agent.yaml
@@ -1,13 +1,72 @@
 #cloud-config
 
-# Parca agent configuration
+# Server-side relabel config for parca-agent, mirrored from the
+# /etc/parca-agent.yml convention used on the Redis OSS benchmark runners:
+#   * drop every sample whose executable is not redis-server so Polar
+#     Signals storage/quota is spent on the module we actually profile
+#     (RediSearch code runs inside the redis-server process)
+#   * promote __meta_thread_id / thread_comm / process_pid to first-class
+#     labels so queries can filter by thread or pid
+#   * default role=primary, override to replica when `replicaof` is in the
+#     process cmdline
+write_files:
+  - path: /etc/parca-agent.yml
+    permissions: '0644'
+    owner: root:root
+    content: |
+      relabel_configs:
+        - source_labels: [__meta_thread_id]
+          target_label: thread_id
+
+        - source_labels: [__meta_thread_comm]
+          target_label: thread_name
+
+        - source_labels: [__meta_process_pid]
+          target_label: pid
+
+        # Drop everything that is NOT redis-server.
+        - source_labels: [__meta_process_executable_name]
+          regex: "^redis-server$"
+          action: keep
+
+        # Default: mark as primary.
+        - target_label: role
+          replacement: primary
+          action: replace
+
+        # Override: mark as replica if "replicaof" appears in cmdline.
+        - source_labels: [__meta_process_cmdline]
+          regex: '.*replicaof.*'
+          target_label: role
+          replacement: replica
+          action: replace
+
+# Parca agent install + wire the config.
+#
+# Channel:
+#   `stable` -> v0.46.0, works with JWT tokens that embed `projectId`.
+#   `edge`   -> v0.47.1+, required when the token is `psc_v1_<secret>_<id>`
+#              (no project binding in the token -- v0.46.0 does not honor
+#              the projectID gRPC header in that case).
+#
+# GRPC headers:
+#   When `parca_agent_project_id` is set, parca-agent is told to route writes
+#   to that project via `--remote-store-grpc-headers=projectID=<id>` (this is
+#   exactly how Polar Signals' own k8s `manifests.yaml` wires the DaemonSet).
+#   Leave the project id empty when using a JWT token that already carries
+#   the project id in its claims.
 snap:
   commands:
-    - [install, parca-agent, --classic]
+    - [install, parca-agent, --classic, --channel=${parca_agent_snap_channel}]
+    - [set, parca-agent, config-path=/etc/parca-agent.yml]
     - [
         set,
         parca-agent,
         remote-store-bearer-token=${parca_agent_token},
       ]
+    - [
+        set,
+        parca-agent,
+        remote-store-grpc-headers=projectID=${parca_agent_project_id},
+      ]
     - [start, --enable, parca-agent]
-

--- a/terraform/oss-standalone-redisearch-m5/db-resources.tf
+++ b/terraform/oss-standalone-redisearch-m5/db-resources.tf
@@ -54,7 +54,9 @@ team     = "performance a&o"
   # Polar Signals Parca agent configuration (optional)
   ################################################################################
   user_data = var.enable_parca_agent ? templatefile("${path.module}/cloud-init-parca-agent.yaml", {
-    parca_agent_token = var.parca_agent_token
+    parca_agent_token        = var.parca_agent_token
+    parca_agent_project_id   = var.parca_agent_project_id
+    parca_agent_snap_channel = var.parca_agent_snap_channel
   }) : null
 
   ################################################################################

--- a/terraform/oss-standalone-redisearch-m5/variables.tf
+++ b/terraform/oss-standalone-redisearch-m5/variables.tf
@@ -193,3 +193,27 @@ variable "parca_agent_token" {
   default     = ""
   sensitive   = true
 }
+
+variable "parca_agent_project_id" {
+  description = <<-EOT
+    Polar Signals project id. Required when parca_agent_token is a
+    `psc_v1_<secret>_<serviceAccountId>` (no project binding in the
+    token) -- passed to parca-agent as `--remote-store-grpc-headers=projectID=<id>`
+    so the server can route writes to the right project. Leave empty
+    when parca_agent_token is a JWT (`eyJ...`) with `projectId` already
+    embedded in its claims.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "parca_agent_snap_channel" {
+  description = <<-EOT
+    Snap channel for parca-agent. v0.46.0 (stable) does not honor the
+    projectID gRPC header with `psc_v1_` tokens; use `edge` (v0.47.1+)
+    for that workflow. Safe to leave as `stable` when using a JWT token
+    with the project id embedded.
+  EOT
+  type        = string
+  default     = "stable"
+}


### PR DESCRIPTION
## Summary

Port the `oss-standalone-redisearch-m7` parca-agent cloud-init + variables to the `oss-standalone-redisearch-m5` module so dispatches that pick the m5 setup also emit profiles to Polar Signals.

## Root cause

The m5 `cloud-init-parca-agent.yaml` only set:

```
snap set parca-agent remote-store-bearer-token=<token>
```

With a `psc_v1_<secret>_<projectId>` style token (no project binding inside the token claims) and parca-agent v0.47+, the agent requires:

```
snap set parca-agent remote-store-grpc-headers=projectID=<id>
```

…or every profile is silently dropped at the remote-store. The m7 module already has this. Dispatching `Run RediSearch Benchmarks` against `redislabsdev/RediSearch` with `allowed_setup=oss-standalone` (which picks m5) produces 0 profile samples in the configured Polar Signals project despite `enable_parca_agent=true` and the agent showing as active on the bench-server.

## Change

m5 now mirrors m7:

- `variables.tf`: add `parca_agent_project_id` (default `""`) + `parca_agent_snap_channel` (default `"stable"`). Defaults preserve current behaviour for callers that only pass the token.
- `db-resources.tf`: thread both new vars through the `templatefile` call.
- `cloud-init-parca-agent.yaml`: replace the truncated install/snap-set block with the full m7 version — relabel_configs file (`__meta_process_executable_name` keep-on-redis-server, thread/pid label promotion, `role` default), the `remote-store-grpc-headers=projectID=…` snap setting, and the channel pin so `parca_agent_snap_channel: edge` picks up v0.47.1+.

After this lands, a `redislabsdev/RediSearch` dispatch with `allowed_setup=oss-standalone` will produce per-test profiles in Polar Signals labeled with the same `test_name` / `git_hash` set the m7 module already emits.

## Test plan

- [ ] Re-dispatch `Run RediSearch Benchmarks` workflow on `redislabsdev/RediSearch` with `allowed_setup=oss-standalone`, `enable_parca_agent=true`, valid `parca_agent_project_id`
- [ ] Verify `git_hash` label value matching the dispatched SHA appears in Polar Signals (project `73d7b9ec-…`)
- [ ] Confirm `test_name` filter narrows samples to a single test as expected
- [ ] Confirm `relabel_configs` keeps only `redis-server` samples (no agent / runtime noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)