### PR TITLE
oss-standalone-redisearch-disk-i7i: optional pre-start dataset placement [MOD-16439]

### DIFF
--- a/terraform/oss-standalone-redisearch-disk-i7i/db-resources.tf
+++ b/terraform/oss-standalone-redisearch-disk-i7i/db-resources.tf
@@ -149,3 +149,45 @@ resource "null_resource" "parca_agent_setup" {
     ]
   }
 }
+
+################################################################################
+# Optional dataset placement via remote-exec (runs after flash_setup, before
+# the benchmark runner starts redis). Used e.g. for prebuilt disk-index trees
+# (BigRedis/SpeedB datadir + restart.rdb) that redis cold-starts from.
+################################################################################
+resource "null_resource" "dataset_placement" {
+  count = var.dataset_tarball_url != "" ? var.server_instance_count : 0
+
+  depends_on = [null_resource.flash_setup]
+
+  triggers = {
+    dataset_url = var.dataset_tarball_url
+    instance_id = aws_instance.server[count.index].id
+  }
+
+  connection {
+    type        = "ssh"
+    user        = var.ssh_user
+    private_key = file(var.private_key)
+    host        = aws_instance.server[count.index].public_ip
+    timeout     = "10m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -e",
+      "echo '=== Dataset placement: ${var.dataset_tarball_url} ==='",
+      "mkdir -p ${var.dataset_extract_dir}",
+      "cd ${var.dataset_extract_dir}",
+      "curl -fsSL --retry 3 -o dataset.tar '${var.dataset_tarball_url}'",
+      "if [ -n '${var.dataset_tarball_sha256}' ]; then echo '${var.dataset_tarball_sha256}  dataset.tar' | sha256sum -c -; fi",
+      "# One pristine copy per benchmark: tests that ingest into the tree",
+      "# mutate it, so each yml points at its own extraction.",
+      "for sub in a b; do mkdir -p $sub && tar -xf dataset.tar -C $sub; done",
+      "rm -f dataset.tar",
+      "echo '=== Dataset placement complete ==='",
+      "ls -la ${var.dataset_extract_dir}",
+      "df -h /mnt/flash"
+    ]
+  }
+}

--- a/terraform/oss-standalone-redisearch-disk-i7i/variables.tf
+++ b/terraform/oss-standalone-redisearch-disk-i7i/variables.tf
@@ -193,3 +193,21 @@ variable "parca_agent_token" {
   default     = ""
   # sensitive   = true  # Temporarily disabled for debugging
 }
+
+################################################################################
+# Optional pre-start dataset placement (e.g. prebuilt BigRedis/SpeedB trees)
+################################################################################
+variable "dataset_tarball_url" {
+  description = "Public URL of a tar archive extracted into dataset_extract_dir on the DB host before the benchmark starts. Empty = skip."
+  default     = ""
+}
+
+variable "dataset_tarball_sha256" {
+  description = "Expected SHA256 of the dataset tarball; verified before extraction when non-empty."
+  default     = ""
+}
+
+variable "dataset_extract_dir" {
+  description = "Directory on the DB host the dataset tarball is extracted into."
+  default     = "/mnt/flash/dataset"
+}


### PR DESCRIPTION
## What

Adds an **optional pre-start dataset placement** step to the `oss-standalone-redisearch-disk-i7i` setup: a `remote-exec` provisioner (mirroring the existing `parca_agent_setup` pattern) that downloads a dataset tarball and extracts it onto the DB host's NVMe after flash setup, before the benchmark runner starts redis.

- Gated by `dataset_tarball_url` — **empty (the default) is a complete no-op**, so existing consumers of this setup are unaffected.
- Optional `dataset_tarball_sha256` verifies the download before extraction.

## Why

First consumer: RediSearchEnterprise vecsim benchmarks (MOD-16439, redislabsdev/RediSearchEnterprise#604) cold-start a prebuilt 3.2M-vector disk-HNSW tree (BigRedis/SpeedB datadir + `restart.rdb`, ~32 GB) instead of a ~2 h from-scratch ingest per run. The tree must be on the DB host's local NVMe before redis starts, which no existing hook provides.

## Validation

Ran green end-to-end in RediSearchEnterprise CI (both benchmark jobs, [run 29261582898](https://github.com/redislabsdev/RediSearchEnterprise/actions/runs/29261582898)): tarball fetched + sha-verified + extracted in ~17 min, redis cold-started from the placed tree in seconds, keyspace check passed (3,245,173 keys).

The RediSearchEnterprise workflow currently pins `testing_infrastructure_branch: dor-forer-i7i-dataset-placement`; merging this lets us drop the pin back to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
